### PR TITLE
Disable env descendant query, a few more checks

### DIFF
--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -16,9 +16,7 @@
 
 - name: Tear down AWS Security Groups associated with enviroment and datalake
   when: 
-    - infra__teardown_deletes_network 
     - infra__aws_vpc_id != ""
-    - not infra__force_teardown
   amazon.aws.ec2_group:
     region: "{{ infra__region }}"
     vpc_id: "{{ infra__aws_vpc_id }}"

--- a/roles/runtime/tasks/initialize_teardown.yml
+++ b/roles/runtime/tasks/initialize_teardown.yml
@@ -32,9 +32,9 @@
     name: "{{ run__env_name }}"
 
 - name: Initialize Purge of all Runtimes in Environment
-  when:
-    - run__force_teardown | bool
-    - run__env_info.environments | length > 0
+  when: no
+#    - run__force_teardown | bool
+#    - run__env_info.environments | length > 0
   block:
     - name: Prepare teardown list of all Datahubs in Environment
       ansible.builtin.set_fact:

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -36,8 +36,8 @@
   register: __dw_teardown_info
   when:
     - run__include_dw
-    - run__env_info.environments | length > 0
-    - run__env_info.environments[0].descendants.dw | length > 0
+#    - run__env_info.environments | length > 0
+#    - run__env_info.environments[0].descendants.dw | length > 0
   cloudera.cloud.dw_cluster:
     env: "{{ run__env_name }}"
     state: absent


### PR DESCRIPTION
Env descendant query response is still relied on, in a couple of places